### PR TITLE
govCMS Administrator check

### DIFF
--- a/src/Controller/GovCMSController.php
+++ b/src/Controller/GovCMSController.php
@@ -12,7 +12,10 @@ class GovCMSController extends TaskController {
    * {@inheritdoc}
    */
   public static function getTasks($task = FALSE) {
-    $tasks = array();
+    $tasks = array(
+      'administrators' => 'DrushAudit\\Task\\GovCMS\\Administrators',
+    );
+
     return $task && isset($tasks[$task]) ? array($tasks[$task]) : $tasks;
   }
 

--- a/src/Task/GovCMS/Administrators.php
+++ b/src/Task/GovCMS/Administrators.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: steven.worley
+ * Date: 6/04/2016
+ * Time: 12:29 PM
+ */
+
+namespace DrushAudit\Task\GovCMS;
+
+use DrushAudit\Task\Task;
+use DrushAudit\Task\TaskTrait;
+
+class Administrators implements Task {
+
+  use TaskTrait;
+
+  public $info = array(
+    'title' => 'Administrator Users',
+    'headers' => array('UID', 'Name', 'Status'),
+  );
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute() {
+    // Ensure that no users are assigned the administrator role.
+    $query = db_select('users', 'u')->fields('u', array('uid', 'name', 'status'));
+    $query->innerJoin('users_roles', 'ur', 'u.uid = ur.uid');
+    $query->innerJoin('role', 'r', 'ur.rid = r.rid');
+    $query->condition('r.name', 'administrator');
+
+    $data = $query->execute()->fetchAll();
+    foreach ($data as &$row) {
+      $row = (array) $row;
+    }
+
+    return $data;
+  }
+}


### PR DESCRIPTION
Security policy for govCMS projects require that no users are assigned to the administrator role. This will list all user accounts who are assigned to administrator so the list can be reviewed.

Fixes #12
