### PR TITLE
Adds view performance checks

### DIFF
--- a/src/Controller/PerformanceController.php
+++ b/src/Controller/PerformanceController.php
@@ -12,6 +12,7 @@ class PerformanceController extends TaskController {
       'cache' => 'DrushAudit\\Task\\Performance\\Cache',
       'settings' => 'DrushAudit\\Task\\Performance\\Settings',
       'modules' => 'DrushAudit\\Task\\Performance\\Modules',
+      'views' => 'DrushAudit\\Task\\Performance\\Views',
     );
 
     if (isset($tasks[$task])) {

--- a/src/Task/Performance/Modules.php
+++ b/src/Task/Performance/Modules.php
@@ -34,7 +34,7 @@ class Modules implements Task {
 
     foreach ($this->getData() as $module) {
       if (in_array($module, array_keys($exclude))) {
-        $output = array($module, $exclude[$module]);
+        $output[] = array($module, $exclude[$module]);
       }
     }
 

--- a/src/Task/Performance/Settings.php
+++ b/src/Task/Performance/Settings.php
@@ -32,11 +32,11 @@ class Settings implements Task {
     }
 
     if (variable_get('preprocess_css') != 1) {
-      $results = array('preprocess_css', 'CSS is not aggregated');
+      $results[] = array('preprocess_css', 'CSS is not aggregated');
     }
 
     if (variable_get('preprocess_js') != 1) {
-      $results = array('preprocess_js', 'JS is not aggregated');
+      $results[] = array('preprocess_js', 'JS is not aggregated');
     }
 
     return $results;

--- a/src/Task/Performance/Views.php
+++ b/src/Task/Performance/Views.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * @file
+ * Contains DrushAudit\Task\Performance\Views.
+ */
+
+namespace DrushAudit\Task\Performance;
+
+use DrushAudit\Task\Task;
+use DrushAudit\Task\TaskTrait;
+
+class Views implements Task {
+
+  use TaskTrait;
+
+  var $info = array(
+    'title' => 'Views',
+    'headers' => array(),
+  );
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct() {
+    $this->setData(views_get_all_views());
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute() {
+    $num = 30; // @TODO: Make this configurable.
+
+    foreach ($this->getData() as $id => $view) {
+      $indent = "  ";
+      drush_print("$indent>> Checking view: $id");
+
+      foreach ($view->display as $display_id => $display) {
+        $indent = "    ";
+        drush_print("$indent>>> $display_id");
+        $indent = "$indent   ";
+
+        if ($display->display_options['cache']['type'] == 'none') {
+          drush_print("$indent- view is not being cached");
+        }
+
+        if ($display->display_options['pager']['options']['items_per_page'] > $num) {
+          drush_print("$indent- view is displaying more than $num items.");
+        }
+
+      }
+
+      drush_print();
+    }
+
+    return array();
+  }
+
+}


### PR DESCRIPTION
Gets the settings for all defined views and ensures that they have been configured correctly. Performs the following checks:
- Ensures that pager settings are displaying an appropriate number of items
- Highlights when caching is not enabled for a particular view

Fixes #27 
Fixes #11 
